### PR TITLE
feat: default due date field to current date

### DIFF
--- a/index.html
+++ b/index.html
@@ -772,8 +772,19 @@
             state.modalOpen = true;
             // Reset form
             todoForm.reset();
+            // Set default due date to today
+            todoDueDateInput.value = getTodayDate();
             // Focus on description input
             setTimeout(() => todoDescriptionInput.focus(), 100);
+        }
+
+        // Get today's date in YYYY-MM-DD format for date input
+        function getTodayDate() {
+            const today = new Date();
+            const year = today.getFullYear();
+            const month = String(today.getMonth() + 1).padStart(2, '0');
+            const day = String(today.getDate()).padStart(2, '0');
+            return `${year}-${month}-${day}`;
         }
 
         function closeModal() {


### PR DESCRIPTION
## Summary
- Pre-populate the due date field with today's date when opening the "New Todo" modal
- User can still modify or clear the date if desired

## Test Plan
- [x] Opening the modal shows today's date in the due date field
- [x] User can change the date to a different value
- [x] User can clear the date field

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)