### PR TITLE
feat: add edit functionality to todos with edit icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -553,6 +553,43 @@
             margin: 6px auto;
         }
 
+        /* Todo actions (edit button) */
+        .todo-actions {
+            display: flex;
+            align-items: center;
+            gap: 4px;
+            margin-left: auto;
+        }
+
+        .todo-edit-btn {
+            width: 32px;
+            height: 32px;
+            border-radius: 6px;
+            border: none;
+            background: transparent;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            transition: background-color 0.2s ease;
+            flex-shrink: 0;
+        }
+
+        .todo-edit-btn:hover {
+            background: #F0F0F0;
+        }
+
+        .todo-edit-btn svg {
+            width: 18px;
+            height: 18px;
+            color: #6C757D;
+            transition: color 0.2s ease;
+        }
+
+        .todo-edit-btn:hover svg {
+            color: #1F1F1F;
+        }
+
         /* Modal responsive */
         @media (max-width: 768px) {
             .modal-content {
@@ -683,7 +720,7 @@
     <div id="todo-modal" class="modal hidden">
         <div class="modal-backdrop" onclick="closeModal()"></div>
         <div class="modal-content">
-            <h2 class="modal-title">New Todo</h2>
+            <h2 id="modal-title" class="modal-title">New Todo</h2>
             <form id="todo-form" onsubmit="saveTodo(event)">
                 <div class="form-group">
                     <label for="todo-description" class="form-label">Description <span class="required">*</span></label>
@@ -706,7 +743,8 @@
         const state = {
             todos: [],
             currentPage: 'landing',
-            modalOpen: false
+            modalOpen: false,
+            editingTodoIndex: null  // Track which todo is being edited (null = create mode)
         };
 
         // DOM Elements
@@ -718,6 +756,7 @@
         const todoForm = document.getElementById('todo-form');
         const todoDescriptionInput = document.getElementById('todo-description');
         const todoDueDateInput = document.getElementById('todo-due-date');
+        const modalTitle = document.getElementById('modal-title');
 
         // Navigation functions
         function navigateTo(page) {
@@ -767,15 +806,34 @@
         }
 
         // Modal functions
-        function openModal() {
+        function openModal(todoIndex = null) {
             todoModal.classList.remove('hidden');
             state.modalOpen = true;
+            state.editingTodoIndex = todoIndex;
+
             // Reset form
             todoForm.reset();
-            // Set default due date to today
-            todoDueDateInput.value = getTodayDate();
+
+            if (todoIndex !== null) {
+                // Edit mode - populate with existing todo data
+                const todo = state.todos[todoIndex];
+                modalTitle.textContent = 'Edit Todo';
+                todoDescriptionInput.value = todo.title;
+                todoDueDateInput.value = todo.dueDate || '';
+            } else {
+                // Create mode
+                modalTitle.textContent = 'New Todo';
+                // Set default due date to today
+                todoDueDateInput.value = getTodayDate();
+            }
+
             // Focus on description input
             setTimeout(() => todoDescriptionInput.focus(), 100);
+        }
+
+        // Edit a todo - opens modal in edit mode
+        function editTodo(index) {
+            openModal(index);
         }
 
         // Get today's date in YYYY-MM-DD format for date input
@@ -790,6 +848,7 @@
         function closeModal() {
             todoModal.classList.add('hidden');
             state.modalOpen = false;
+            state.editingTodoIndex = null;
             todoForm.reset();
         }
 
@@ -798,7 +857,7 @@
             return Date.now().toString(36) + Math.random().toString(36).substr(2, 9);
         }
 
-        // Save todo
+        // Save todo (handles both create and update)
         function saveTodo(event) {
             event.preventDefault();
 
@@ -807,15 +866,24 @@
 
             if (!description) return;
 
-            const newTodo = {
-                id: generateId(),
-                title: description,
-                dueDate: dueDate || null,
-                completed: false,
-                createdAt: new Date().toISOString()
-            };
+            if (state.editingTodoIndex !== null) {
+                // Update existing todo
+                const todo = state.todos[state.editingTodoIndex];
+                todo.title = description;
+                todo.dueDate = dueDate || null;
+                // Preserve id, completed, and createdAt
+            } else {
+                // Create new todo
+                const newTodo = {
+                    id: generateId(),
+                    title: description,
+                    dueDate: dueDate || null,
+                    completed: false,
+                    createdAt: new Date().toISOString()
+                };
+                state.todos.push(newTodo);
+            }
 
-            state.todos.push(newTodo);
             closeModal();
             renderTodos();
         }
@@ -855,6 +923,14 @@
                         <div class="todo-content">
                             <div class="todo-title">${escapeHtml(todo.title)}</div>
                             ${dueDateHtml}
+                        </div>
+                        <div class="todo-actions">
+                            <button class="todo-edit-btn" onclick="editTodo(${index})" title="Edit">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                    <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
+                                    <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
+                                </svg>
+                            </button>
                         </div>
                     `;
                     todoList.appendChild(todoItem);


### PR DESCRIPTION
## Summary
- Add pencil/edit icon to each todo item in the list view
- Click edit icon to open modal in "Edit Todo" mode
- Pre-populate form fields with existing todo data
- Update existing todo on save (preserves ID and completion status)

## Test Plan
- [x] Each todo item displays an edit icon (pencil)
- [x] Clicking edit icon opens modal with "Edit Todo" title
- [x] Description field is pre-populated with existing value
- [x] Due date field is pre-populated with existing value
- [x] Saving updates the todo without creating a new one
- [x] Todo ID and completion status are preserved after edit
- [x] Cancel/Escape closes modal without saving

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)