### PR TITLE
Issue-18: Settings View with Left Menu Navigation

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1549,7 +1549,7 @@
         }
 
         .settings-menu {
-            width: 40%;
+            width: 20%;
             background: #FFFFFF;
             border-right: 1px solid #E0E0E0;
             padding: 24px 0;
@@ -1606,7 +1606,7 @@
         }
 
         .settings-content {
-            width: 60%;
+            width: 80%;
             position: relative;
             padding: 24px;
             overflow-y: auto;


### PR DESCRIPTION
## Summary
- Transforms Settings page into a structured view with vertical left menu (40% width) and content area (60% width)
- Adds "People" as the first menu section with multi-user icon and highlighted selection state
- Adds floating close button (X) in top-right of content pane to return to previous page

## Changes
- Added CSS styles for settings layout with 40/60 split
- Refactored people page HTML into settings content area
- Added `switchSettingsSection()` function for future extensibility
- Tracks `previousTab` in state for return navigation
- Updated keyboard shortcut to work within settings page

## Test plan
- [x] Click Settings icon opens settings view with left menu and content area
- [x] Left menu shows "People" with multi-user icon highlighted
- [x] Close button returns to previous page (tested from both Todo's and Opportunities)
- [x] Shift+N still creates new person within settings

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)