### PR TITLE
Issue-20: Implement Tags Management feature

### DIFF
--- a/ISSUETRACKER.md
+++ b/ISSUETRACKER.md
@@ -1,3 +1,5 @@
 # Issue Tracker
 
 Issue-18: Implemented export/import functionality to save and restore app state via JSON files with timestamped filenames.
+
+Issue-20: Implemented Tags Management feature with CRUD operations in Settings, inline tag assignment for Todos and Opportunities via autocomplete dropdown with inline creation, and colored tag pills display in list views.

--- a/src/index.html
+++ b/src/index.html
@@ -1627,6 +1627,119 @@
             font-style: italic;
         }
 
+        /* Tag input control for forms */
+        .tag-input-container {
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+        }
+
+        .selected-tags {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+        }
+
+        .selected-tag {
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+            padding: 4px 8px;
+            font-size: 12px;
+            font-weight: 500;
+            border-radius: 12px;
+            color: #fff;
+        }
+
+        .selected-tag .remove-tag {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 14px;
+            height: 14px;
+            border: none;
+            background: rgba(255, 255, 255, 0.3);
+            border-radius: 50%;
+            cursor: pointer;
+            padding: 0;
+            font-size: 10px;
+            color: inherit;
+            line-height: 1;
+        }
+
+        .selected-tag .remove-tag:hover {
+            background: rgba(255, 255, 255, 0.5);
+        }
+
+        .tag-input-wrapper {
+            position: relative;
+        }
+
+        .tag-input {
+            width: 100%;
+            padding: 8px 12px;
+            border: 1px solid #E0E0E0;
+            border-radius: 8px;
+            font-size: 14px;
+            background: #F5F5F5;
+            transition: all 0.2s ease;
+        }
+
+        .tag-input:focus {
+            outline: none;
+            border-color: #F59E0B;
+            background: #fff;
+        }
+
+        .tag-dropdown {
+            position: absolute;
+            top: 100%;
+            left: 0;
+            right: 0;
+            background: #fff;
+            border: 1px solid #E0E0E0;
+            border-radius: 8px;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+            z-index: 100;
+            max-height: 200px;
+            overflow-y: auto;
+            display: none;
+        }
+
+        .tag-dropdown.open {
+            display: block;
+        }
+
+        .tag-dropdown-item {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            padding: 10px 12px;
+            cursor: pointer;
+            transition: background 0.2s ease;
+        }
+
+        .tag-dropdown-item:hover,
+        .tag-dropdown-item.highlighted {
+            background: #F5F5F5;
+        }
+
+        .tag-dropdown-item .tag-color-dot {
+            width: 12px;
+            height: 12px;
+            border-radius: 50%;
+        }
+
+        .tag-dropdown-item.create-new {
+            border-top: 1px solid #E0E0E0;
+            color: #F59E0B;
+            font-weight: 500;
+        }
+
+        .tag-dropdown-item.create-new .tag-color-dot {
+            background: #F59E0B;
+        }
+
         /* Inline person creation form */
         .inline-person-form {
             max-height: 0;
@@ -2240,6 +2353,21 @@
                         </div>
                     </div>
                 </div>
+                <!-- Tags Section -->
+                <div class="form-group">
+                    <label class="form-label">Tags</label>
+                    <div class="tag-input-container" id="todo-tag-container">
+                        <div class="selected-tags" id="todo-selected-tags">
+                            <!-- Selected tags will be rendered here -->
+                        </div>
+                        <div class="tag-input-wrapper">
+                            <input type="text" id="todo-tag-input" class="tag-input" placeholder="Type to add tags..." autocomplete="off">
+                            <div id="todo-tag-dropdown" class="tag-dropdown">
+                                <!-- Tag suggestions will be rendered here -->
+                            </div>
+                        </div>
+                    </div>
+                </div>
                 <div class="modal-actions">
                     <button type="button" class="btn btn-secondary" onclick="closeModal()">Cancel</button>
                     <button type="submit" class="btn btn-primary">Save</button>
@@ -2291,6 +2419,21 @@
                         <div class="form-group">
                             <label for="inline-person-role" class="form-label">Role</label>
                             <input type="text" id="inline-person-role" class="form-input" placeholder="Person's role">
+                        </div>
+                    </div>
+                </div>
+                <!-- Tags Section -->
+                <div class="form-group">
+                    <label class="form-label">Tags</label>
+                    <div class="tag-input-container" id="opp-tag-container">
+                        <div class="selected-tags" id="opp-selected-tags">
+                            <!-- Selected tags will be rendered here -->
+                        </div>
+                        <div class="tag-input-wrapper">
+                            <input type="text" id="opp-tag-input" class="tag-input" placeholder="Type to add tags..." autocomplete="off">
+                            <div id="opp-tag-dropdown" class="tag-dropdown">
+                                <!-- Tag suggestions will be rendered here -->
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -2408,6 +2551,8 @@
             sidePanelOpen: false,
             editingTodoIndex: null,  // Track which todo is being edited (null = create mode)
             editingPersonIndex: null,  // Track which person is being edited (null = create mode)
+            editingTagIndex: null,  // Track which tag is being edited (null = create mode)
+            tagModalOpen: false,
             selectedOpportunityIndex: null,  // Track which opportunity is open in side panel
             deleteOpportunityIndex: null,  // Track which opportunity is pending deletion
             deletePersonIndex: null,  // Track which person is pending deletion
@@ -2431,7 +2576,14 @@
             inlineOppPersonFormOpen: false,
             selectedInlineOppPersonId: null,
             pendingInlineOppPerson: null,
-            showArchived: false
+            showArchived: false,
+            // Tag assignment state
+            selectedTodoTagIds: [],  // Tag IDs selected for current todo
+            selectedOppTagIds: [],   // Tag IDs selected for current opportunity
+            todoTagDropdownOpen: false,
+            todoTagHighlightIndex: -1,
+            oppTagDropdownOpen: false,
+            oppTagHighlightIndex: -1
         };
 
         // DOM Elements - Landing and Home
@@ -2532,6 +2684,16 @@
         const tagColorPreview = document.getElementById('tag-color-preview');
         const tagColorValue = document.getElementById('tag-color-value');
 
+        // DOM Elements - Tag Input (Todo form)
+        const todoTagInput = document.getElementById('todo-tag-input');
+        const todoTagDropdown = document.getElementById('todo-tag-dropdown');
+        const todoSelectedTags = document.getElementById('todo-selected-tags');
+
+        // DOM Elements - Tag Input (Opportunity form)
+        const oppTagInput = document.getElementById('opp-tag-input');
+        const oppTagDropdown = document.getElementById('opp-tag-dropdown');
+        const oppSelectedTags = document.getElementById('opp-selected-tags');
+
         // DOM Elements - Person Modal
         const personModal = document.getElementById('person-modal');
         const personModalTitle = document.getElementById('person-modal-title');
@@ -2611,7 +2773,7 @@
             switchTab(state.previousTab);
         }
 
-        // Switch settings section (for future extensibility)
+        // Switch settings section
         function switchSettingsSection(section) {
             state.settingsSection = section;
 
@@ -2621,10 +2783,18 @@
                 item.classList.toggle('active', item.dataset.section === section);
             });
 
-            // For now, only People section exists
-            // Future sections would be shown/hidden here
+            // Toggle section visibility
+            const peopleSection = document.getElementById('settings-section-people');
+            const tagsSection = document.getElementById('settings-section-tags');
+
             if (section === 'people') {
+                peopleSection.classList.remove('hidden');
+                tagsSection.classList.add('hidden');
                 renderPeople();
+            } else if (section === 'tags') {
+                peopleSection.classList.add('hidden');
+                tagsSection.classList.remove('hidden');
+                renderTags();
             }
         }
 
@@ -2760,6 +2930,13 @@
             inlineOppContactDropdown.classList.remove('open');
             inlineOppPersonForm.classList.remove('open');
 
+            // Reset tag input state
+            state.selectedTodoTagIds = [];
+            state.todoTagDropdownOpen = false;
+            state.todoTagHighlightIndex = -1;
+            todoTagInput.value = '';
+            closeTodoTagDropdown();
+
             if (todoIndex !== null) {
                 // Edit mode - populate with existing todo data
                 const todo = state.todos[todoIndex];
@@ -2776,12 +2953,20 @@
                         todoOpportunityClear.classList.add('visible');
                     }
                 }
+
+                // Pre-populate tags
+                if (todo.tagIds && Array.isArray(todo.tagIds)) {
+                    state.selectedTodoTagIds = [...todo.tagIds];
+                }
             } else {
                 // Create mode
                 modalTitle.textContent = 'New Todo';
                 // Set default due date to today
                 todoDueDateInput.value = getTodayDate();
             }
+
+            // Render selected tags
+            renderTodoSelectedTags();
 
             // Focus on description input
             setTimeout(() => todoDescriptionInput.focus(), 100);
@@ -2893,6 +3078,7 @@
                 todo.title = description;
                 todo.dueDate = dueDate || null;
                 todo.opportunityId = opportunityId;
+                todo.tagIds = [...state.selectedTodoTagIds];
                 // Preserve id, completed, and createdAt
             } else {
                 // Create new todo
@@ -2901,6 +3087,7 @@
                     title: description,
                     dueDate: dueDate || null,
                     opportunityId: opportunityId,
+                    tagIds: [...state.selectedTodoTagIds],
                     completed: false,
                     createdAt: new Date().toISOString()
                 };
@@ -2999,12 +3186,28 @@
                         }
                     }
 
+                    // Format tags
+                    let tagsHtml = '';
+                    if (todo.tagIds && todo.tagIds.length > 0) {
+                        const tagPills = todo.tagIds.map(tagId => {
+                            const tag = getTagById(tagId);
+                            if (tag) {
+                                return `<span class="tag-pill" style="background-color: ${tag.color}; color: #fff;">${escapeHtml(tag.name)}</span>`;
+                            }
+                            return '';
+                        }).filter(Boolean).join('');
+                        if (tagPills) {
+                            tagsHtml = `<div class="tags-container">${tagPills}</div>`;
+                        }
+                    }
+
                     todoItem.innerHTML = `
                         <div class="todo-checkbox ${todo.completed ? 'checked' : ''}" onclick="toggleTodo(${index})"></div>
                         <div class="todo-content">
                             <div class="todo-title">${escapeHtml(todo.title)}</div>
                             ${dueDateHtml}
                             ${opportunityHtml}
+                            ${tagsHtml}
                         </div>
                         <div class="todo-actions">
                             <button class="todo-edit-btn" onclick="editTodo(${index})" title="Edit">
@@ -3070,6 +3273,14 @@
             contactDropdown.classList.remove('open');
             inlinePersonForm.classList.remove('open');
 
+            // Reset tag input state
+            state.selectedOppTagIds = [];
+            state.oppTagDropdownOpen = false;
+            state.oppTagHighlightIndex = -1;
+            oppTagInput.value = '';
+            closeOppTagDropdown();
+            renderOppSelectedTags();
+
             // Focus on name input
             setTimeout(() => oppNameInput.focus(), 100);
         }
@@ -3118,6 +3329,7 @@
                 startDate: startDate || getTodayDate(),
                 contact: contactName || null,  // Keep text for display
                 contactId: contactId || null,  // Link to person
+                tagIds: [...state.selectedOppTagIds],
                 status: 'requested',  // Default status
                 comments: [],
                 archived: false,
@@ -3210,10 +3422,26 @@
                     }
                     // No buttons for archived opportunities
 
+                    // Format tags for opportunity
+                    let oppTagsHtml = '';
+                    if (opp.tagIds && opp.tagIds.length > 0) {
+                        const tagPills = opp.tagIds.map(tagId => {
+                            const tag = getTagById(tagId);
+                            if (tag) {
+                                return `<span class="tag-pill" style="background-color: ${tag.color}; color: #fff;">${escapeHtml(tag.name)}</span>`;
+                            }
+                            return '';
+                        }).filter(Boolean).join('');
+                        if (tagPills) {
+                            oppTagsHtml = `<div class="tags-container">${tagPills}</div>`;
+                        }
+                    }
+
                     oppItem.innerHTML = `
                         <div class="opportunity-content" onclick="openSidePanel(${index})">
                             <div class="opportunity-name">${escapeHtml(opp.name)}</div>
                             ${opp.contact ? `<div class="opportunity-contact">${escapeHtml(opp.contact)}</div>` : ''}
+                            ${oppTagsHtml}
                         </div>
                         <span class="status-badge ${statusClass}">${capitalizeFirst(opp.status)}</span>
                         <div class="opportunity-actions">
@@ -3795,6 +4023,469 @@
                 rolesList.appendChild(roleTag);
             });
         }
+
+        // Render tags list in Settings
+        function renderTags() {
+            tagsList.innerHTML = '';
+
+            if (state.tags.length === 0) {
+                // Show empty state
+                tagsList.classList.add('hidden');
+                tagsEmptyState.classList.remove('hidden');
+                tagsShortcutHintFloating.classList.add('hidden');
+            } else {
+                // Show tags list
+                tagsList.classList.remove('hidden');
+                tagsEmptyState.classList.add('hidden');
+                tagsShortcutHintFloating.classList.remove('hidden');
+
+                state.tags.forEach((tag, index) => {
+                    const tagItem = document.createElement('div');
+                    tagItem.className = 'tag-item';
+
+                    tagItem.innerHTML = `
+                        <div class="tag-info">
+                            <div class="tag-color-preview" style="background-color: ${tag.color}"></div>
+                            <div class="tag-name">${escapeHtml(tag.name)}</div>
+                        </div>
+                        <div class="tag-actions">
+                            <button class="action-btn" onclick="event.stopPropagation(); openTagModal(${index})" title="Edit">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                    <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
+                                    <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
+                                </svg>
+                            </button>
+                            <button class="action-btn action-btn-danger" onclick="event.stopPropagation(); deleteTag(${index})" title="Delete">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                    <polyline points="3 6 5 6 21 6"></polyline>
+                                    <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
+                                </svg>
+                            </button>
+                        </div>
+                    `;
+
+                    tagsList.appendChild(tagItem);
+                });
+            }
+
+            saveData();
+        }
+
+        // Open tag modal
+        function openTagModal(tagIndex = null) {
+            state.tagModalOpen = true;
+            state.editingTagIndex = tagIndex;
+
+            if (tagIndex !== null) {
+                // Edit mode
+                const tag = state.tags[tagIndex];
+                tagModalTitle.textContent = 'Edit Tag';
+                tagNameInput.value = tag.name;
+                tagColorInput.value = tag.color;
+                updateColorPreview(tag.color);
+            } else {
+                // Create mode
+                tagModalTitle.textContent = 'New Tag';
+                tagNameInput.value = '';
+                tagColorInput.value = '#F59E0B';
+                updateColorPreview('#F59E0B');
+            }
+
+            tagModal.classList.remove('hidden');
+            setTimeout(() => tagNameInput.focus(), 100);
+        }
+
+        // Close tag modal
+        function closeTagModal() {
+            state.tagModalOpen = false;
+            state.editingTagIndex = null;
+            tagModal.classList.add('hidden');
+            tagForm.reset();
+        }
+
+        // Update color preview
+        function updateColorPreview(color) {
+            tagColorPreview.style.backgroundColor = color;
+            tagColorValue.textContent = color.toUpperCase();
+        }
+
+        // Save tag
+        function saveTag(e) {
+            e.preventDefault();
+
+            const name = tagNameInput.value.trim();
+            if (!name) return;
+
+            const color = tagColorInput.value;
+
+            if (state.editingTagIndex !== null) {
+                // Update existing tag
+                state.tags[state.editingTagIndex].name = name;
+                state.tags[state.editingTagIndex].color = color;
+            } else {
+                // Create new tag
+                const newTag = {
+                    id: generateId(),
+                    name: name,
+                    color: color,
+                    createdAt: new Date().toISOString()
+                };
+                state.tags.push(newTag);
+            }
+
+            closeTagModal();
+            renderTags();
+        }
+
+        // Delete tag
+        function deleteTag(index) {
+            const tag = state.tags[index];
+
+            // Remove tag from all todos and opportunities
+            state.todos.forEach(todo => {
+                if (todo.tagIds) {
+                    todo.tagIds = todo.tagIds.filter(id => id !== tag.id);
+                }
+            });
+            state.opportunities.forEach(opp => {
+                if (opp.tagIds) {
+                    opp.tagIds = opp.tagIds.filter(id => id !== tag.id);
+                }
+            });
+
+            // Remove tag from array
+            state.tags.splice(index, 1);
+            renderTags();
+        }
+
+        // Get tag by ID
+        function getTagById(tagId) {
+            return state.tags.find(t => t.id === tagId);
+        }
+
+        // Get or create tag by name (for inline creation)
+        function getOrCreateTag(tagName) {
+            if (!tagName || tagName.trim() === '') return null;
+            const trimmedName = tagName.trim();
+            const existingTag = state.tags.find(t => t.name.toLowerCase() === trimmedName.toLowerCase());
+            if (existingTag) return existingTag.id;
+
+            // Create new tag with default color
+            const defaultColors = ['#F59E0B', '#10B981', '#3B82F6', '#8B5CF6', '#EC4899', '#EF4444'];
+            const colorIndex = state.tags.length % defaultColors.length;
+            const newTag = {
+                id: generateId(),
+                name: trimmedName,
+                color: defaultColors[colorIndex],
+                createdAt: new Date().toISOString()
+            };
+            state.tags.push(newTag);
+            return newTag.id;
+        }
+
+        // ==================== Tag Input Functions ====================
+
+        // Render selected tags for Todo form
+        function renderTodoSelectedTags() {
+            todoSelectedTags.innerHTML = '';
+            state.selectedTodoTagIds.forEach(tagId => {
+                const tag = getTagById(tagId);
+                if (tag) {
+                    const tagEl = document.createElement('span');
+                    tagEl.className = 'selected-tag';
+                    tagEl.style.backgroundColor = tag.color;
+                    tagEl.innerHTML = `
+                        ${escapeHtml(tag.name)}
+                        <button type="button" class="remove-tag" onclick="removeTodoTag('${tagId}')">×</button>
+                    `;
+                    todoSelectedTags.appendChild(tagEl);
+                }
+            });
+        }
+
+        // Render selected tags for Opportunity form
+        function renderOppSelectedTags() {
+            oppSelectedTags.innerHTML = '';
+            state.selectedOppTagIds.forEach(tagId => {
+                const tag = getTagById(tagId);
+                if (tag) {
+                    const tagEl = document.createElement('span');
+                    tagEl.className = 'selected-tag';
+                    tagEl.style.backgroundColor = tag.color;
+                    tagEl.innerHTML = `
+                        ${escapeHtml(tag.name)}
+                        <button type="button" class="remove-tag" onclick="removeOppTag('${tagId}')">×</button>
+                    `;
+                    oppSelectedTags.appendChild(tagEl);
+                }
+            });
+        }
+
+        // Remove tag from Todo
+        function removeTodoTag(tagId) {
+            state.selectedTodoTagIds = state.selectedTodoTagIds.filter(id => id !== tagId);
+            renderTodoSelectedTags();
+        }
+
+        // Remove tag from Opportunity
+        function removeOppTag(tagId) {
+            state.selectedOppTagIds = state.selectedOppTagIds.filter(id => id !== tagId);
+            renderOppSelectedTags();
+        }
+
+        // Render tag dropdown for Todo
+        function renderTodoTagDropdown(filter = '') {
+            todoTagDropdown.innerHTML = '';
+            const filterLower = filter.toLowerCase();
+
+            // Filter tags not already selected and matching the filter
+            const availableTags = state.tags.filter(tag =>
+                !state.selectedTodoTagIds.includes(tag.id) &&
+                tag.name.toLowerCase().includes(filterLower)
+            );
+
+            availableTags.forEach((tag, index) => {
+                const item = document.createElement('div');
+                item.className = 'tag-dropdown-item' + (index === state.todoTagHighlightIndex ? ' highlighted' : '');
+                item.innerHTML = `
+                    <span class="tag-color-dot" style="background-color: ${tag.color}"></span>
+                    ${escapeHtml(tag.name)}
+                `;
+                item.onclick = () => selectTodoTag(tag.id);
+                todoTagDropdown.appendChild(item);
+            });
+
+            // Show "create new" option if filter doesn't match existing tag exactly
+            if (filter.trim() && !state.tags.some(t => t.name.toLowerCase() === filterLower)) {
+                const createItem = document.createElement('div');
+                createItem.className = 'tag-dropdown-item create-new' + (availableTags.length === state.todoTagHighlightIndex ? ' highlighted' : '');
+                createItem.innerHTML = `
+                    <span class="tag-color-dot"></span>
+                    Create "${escapeHtml(filter.trim())}"
+                `;
+                createItem.onclick = () => createAndSelectTodoTag(filter.trim());
+                todoTagDropdown.appendChild(createItem);
+            }
+
+            if (todoTagDropdown.children.length > 0) {
+                todoTagDropdown.classList.add('open');
+                state.todoTagDropdownOpen = true;
+            } else {
+                todoTagDropdown.classList.remove('open');
+                state.todoTagDropdownOpen = false;
+            }
+        }
+
+        // Render tag dropdown for Opportunity
+        function renderOppTagDropdown(filter = '') {
+            oppTagDropdown.innerHTML = '';
+            const filterLower = filter.toLowerCase();
+
+            // Filter tags not already selected and matching the filter
+            const availableTags = state.tags.filter(tag =>
+                !state.selectedOppTagIds.includes(tag.id) &&
+                tag.name.toLowerCase().includes(filterLower)
+            );
+
+            availableTags.forEach((tag, index) => {
+                const item = document.createElement('div');
+                item.className = 'tag-dropdown-item' + (index === state.oppTagHighlightIndex ? ' highlighted' : '');
+                item.innerHTML = `
+                    <span class="tag-color-dot" style="background-color: ${tag.color}"></span>
+                    ${escapeHtml(tag.name)}
+                `;
+                item.onclick = () => selectOppTag(tag.id);
+                oppTagDropdown.appendChild(item);
+            });
+
+            // Show "create new" option if filter doesn't match existing tag exactly
+            if (filter.trim() && !state.tags.some(t => t.name.toLowerCase() === filterLower)) {
+                const createItem = document.createElement('div');
+                createItem.className = 'tag-dropdown-item create-new' + (availableTags.length === state.oppTagHighlightIndex ? ' highlighted' : '');
+                createItem.innerHTML = `
+                    <span class="tag-color-dot"></span>
+                    Create "${escapeHtml(filter.trim())}"
+                `;
+                createItem.onclick = () => createAndSelectOppTag(filter.trim());
+                oppTagDropdown.appendChild(createItem);
+            }
+
+            if (oppTagDropdown.children.length > 0) {
+                oppTagDropdown.classList.add('open');
+                state.oppTagDropdownOpen = true;
+            } else {
+                oppTagDropdown.classList.remove('open');
+                state.oppTagDropdownOpen = false;
+            }
+        }
+
+        // Select existing tag for Todo
+        function selectTodoTag(tagId) {
+            if (!state.selectedTodoTagIds.includes(tagId)) {
+                state.selectedTodoTagIds.push(tagId);
+                renderTodoSelectedTags();
+            }
+            todoTagInput.value = '';
+            closeTodoTagDropdown();
+        }
+
+        // Select existing tag for Opportunity
+        function selectOppTag(tagId) {
+            if (!state.selectedOppTagIds.includes(tagId)) {
+                state.selectedOppTagIds.push(tagId);
+                renderOppSelectedTags();
+            }
+            oppTagInput.value = '';
+            closeOppTagDropdown();
+        }
+
+        // Create new tag and select it for Todo
+        function createAndSelectTodoTag(name) {
+            const tagId = getOrCreateTag(name);
+            if (tagId) {
+                selectTodoTag(tagId);
+            }
+        }
+
+        // Create new tag and select it for Opportunity
+        function createAndSelectOppTag(name) {
+            const tagId = getOrCreateTag(name);
+            if (tagId) {
+                selectOppTag(tagId);
+            }
+        }
+
+        // Close Todo tag dropdown
+        function closeTodoTagDropdown() {
+            todoTagDropdown.classList.remove('open');
+            state.todoTagDropdownOpen = false;
+            state.todoTagHighlightIndex = -1;
+        }
+
+        // Close Opportunity tag dropdown
+        function closeOppTagDropdown() {
+            oppTagDropdown.classList.remove('open');
+            state.oppTagDropdownOpen = false;
+            state.oppTagHighlightIndex = -1;
+        }
+
+        // Setup tag input event listeners
+        function setupTagInputListeners() {
+            // Todo tag input
+            todoTagInput.addEventListener('input', (e) => {
+                state.todoTagHighlightIndex = -1;
+                renderTodoTagDropdown(e.target.value);
+            });
+
+            todoTagInput.addEventListener('focus', () => {
+                renderTodoTagDropdown(todoTagInput.value);
+            });
+
+            todoTagInput.addEventListener('keydown', (e) => {
+                if (e.key === 'Escape') {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    closeTodoTagDropdown();
+                    todoTagInput.value = '';
+                    return;
+                }
+
+                if (e.key === 'Enter') {
+                    e.preventDefault();
+                    const items = todoTagDropdown.querySelectorAll('.tag-dropdown-item');
+                    if (state.todoTagHighlightIndex >= 0 && state.todoTagHighlightIndex < items.length) {
+                        items[state.todoTagHighlightIndex].click();
+                    } else if (todoTagInput.value.trim()) {
+                        createAndSelectTodoTag(todoTagInput.value.trim());
+                    }
+                    return;
+                }
+
+                if (e.key === 'ArrowDown') {
+                    e.preventDefault();
+                    const items = todoTagDropdown.querySelectorAll('.tag-dropdown-item');
+                    if (items.length > 0) {
+                        state.todoTagHighlightIndex = Math.min(state.todoTagHighlightIndex + 1, items.length - 1);
+                        renderTodoTagDropdown(todoTagInput.value);
+                    }
+                    return;
+                }
+
+                if (e.key === 'ArrowUp') {
+                    e.preventDefault();
+                    if (state.todoTagHighlightIndex > 0) {
+                        state.todoTagHighlightIndex--;
+                        renderTodoTagDropdown(todoTagInput.value);
+                    }
+                    return;
+                }
+            });
+
+            // Opportunity tag input
+            oppTagInput.addEventListener('input', (e) => {
+                state.oppTagHighlightIndex = -1;
+                renderOppTagDropdown(e.target.value);
+            });
+
+            oppTagInput.addEventListener('focus', () => {
+                renderOppTagDropdown(oppTagInput.value);
+            });
+
+            oppTagInput.addEventListener('keydown', (e) => {
+                if (e.key === 'Escape') {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    closeOppTagDropdown();
+                    oppTagInput.value = '';
+                    return;
+                }
+
+                if (e.key === 'Enter') {
+                    e.preventDefault();
+                    const items = oppTagDropdown.querySelectorAll('.tag-dropdown-item');
+                    if (state.oppTagHighlightIndex >= 0 && state.oppTagHighlightIndex < items.length) {
+                        items[state.oppTagHighlightIndex].click();
+                    } else if (oppTagInput.value.trim()) {
+                        createAndSelectOppTag(oppTagInput.value.trim());
+                    }
+                    return;
+                }
+
+                if (e.key === 'ArrowDown') {
+                    e.preventDefault();
+                    const items = oppTagDropdown.querySelectorAll('.tag-dropdown-item');
+                    if (items.length > 0) {
+                        state.oppTagHighlightIndex = Math.min(state.oppTagHighlightIndex + 1, items.length - 1);
+                        renderOppTagDropdown(oppTagInput.value);
+                    }
+                    return;
+                }
+
+                if (e.key === 'ArrowUp') {
+                    e.preventDefault();
+                    if (state.oppTagHighlightIndex > 0) {
+                        state.oppTagHighlightIndex--;
+                        renderOppTagDropdown(oppTagInput.value);
+                    }
+                    return;
+                }
+            });
+
+            // Close dropdowns when clicking outside
+            document.addEventListener('click', (e) => {
+                if (!e.target.closest('#todo-tag-container')) {
+                    closeTodoTagDropdown();
+                }
+                if (!e.target.closest('#opp-tag-container')) {
+                    closeOppTagDropdown();
+                }
+            });
+        }
+
+        // Initialize tag input listeners
+        setupTagInputListeners();
+
+        // ==================== End Tag Input Functions ====================
 
         // Get role name by ID
         function getRoleName(roleId) {
@@ -4550,6 +5241,14 @@
                 return;
             }
 
+            // Handle Shift+N to open tag modal (only on settings page with tags section)
+            if (e.shiftKey && !e.ctrlKey && !e.altKey && !e.metaKey && e.key.toLowerCase() === 'n' &&
+                state.currentPage === 'app' && state.currentTab === 'settings' && state.settingsSection === 'tags' && !anyModalOpen) {
+                e.preventDefault();
+                openTagModal();
+                return;
+            }
+
             // Handle Escape key to close modals or side panel
             if (e.key === 'Escape') {
                 if (state.cancelModalOpen) {
@@ -4575,6 +5274,11 @@
                 if (state.personModalOpen) {
                     e.preventDefault();
                     closePersonModal();
+                    return;
+                }
+                if (state.tagModalOpen) {
+                    e.preventDefault();
+                    closeTagModal();
                     return;
                 }
                 if (state.deletePersonIndex !== null) {


### PR DESCRIPTION
## Summary
- Fix Settings section switching to properly toggle between People and Tags views
- Implement complete Tags CRUD operations in Settings (create, edit, delete tags with colors)
- Add inline tag assignment to Todo and Opportunity forms with autocomplete dropdown and inline creation
- Display tags as colored pills in both Todo and Opportunity list views

## Test plan
- [x] Verify Settings > Tags section displays correctly
- [x] Create new tags with name and color
- [x] Edit existing tags
- [x] Delete tags
- [x] Add tags to Todos via inline input
- [x] Add tags to Opportunities via inline input
- [x] Verify tags display as colored pills in list views
- [x] Test keyboard shortcuts (Shift+N, Escape)
- [x] Test import/export includes tags data

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)