### PR TITLE
Issue-39: Add Todo description to card with two-column layout

### DIFF
--- a/ISSUETRACKER.md
+++ b/ISSUETRACKER.md
@@ -18,3 +18,5 @@ Issue-32: Improved Tab key navigation in autocomplete dropdowns. When dropdown i
 Issue-35: Fixed autocomplete dropdowns resetting to previous value when re-focusing and typing new selection by auto-highlighting first match and using filtered options list.
 
 Issue-37: Fixed Shift+Tab navigation loop in Todo modal. Tab handlers were intercepting Shift+Tab and forcing focus forward to Tags, causing backward navigation to loop. Added `!e.shiftKey` check to all Tab key handlers so Shift+Tab navigates naturally backward through the form.
+
+Issue-39: Added Todo description to card with two-column layout displaying description on the right side of the existing info.

--- a/src/index.html
+++ b/src/index.html
@@ -382,6 +382,30 @@
 
         .todo-content {
             flex: 1;
+            display: flex;
+            gap: 16px;
+            align-items: flex-start;
+        }
+
+        .todo-info {
+            flex: 0 0 auto;
+            min-width: 180px;
+            max-width: 50%;
+        }
+
+        .todo-description {
+            flex: 1;
+            font-size: 13px;
+            color: #6C757D;
+            line-height: 1.4;
+            overflow: hidden;
+            display: -webkit-box;
+            -webkit-line-clamp: 3;
+            -webkit-box-orient: vertical;
+        }
+
+        .todo-item.completed .todo-description {
+            color: #ADB5BD;
         }
 
         .todo-title {
@@ -4515,13 +4539,22 @@
                         tagsHtml = `<div class="tags-container">${tagPills.join('')}</div>`;
                     }
 
+                    // Format description for two-column layout
+                    let descriptionHtml = '';
+                    if (todo.description && todo.description.trim()) {
+                        descriptionHtml = `<div class="todo-description">${escapeHtml(todo.description)}</div>`;
+                    }
+
                     todoItem.innerHTML = `
                         <div class="todo-checkbox ${todo.completed ? 'checked' : ''}" onclick="toggleTodo(${index})"></div>
                         <div class="todo-content">
-                            <div class="todo-title">${escapeHtml(todo.title)}</div>
-                            ${dueDateHtml}
-                            ${opportunityHtml}
-                            ${tagsHtml}
+                            <div class="todo-info">
+                                <div class="todo-title">${escapeHtml(todo.title)}</div>
+                                ${dueDateHtml}
+                                ${opportunityHtml}
+                                ${tagsHtml}
+                            </div>
+                            ${descriptionHtml}
                         </div>
                         <div class="todo-actions">
                             <button class="todo-edit-btn" onclick="editTodo(${index})" title="Edit">


### PR DESCRIPTION
## Summary
- Changed Todo card layout to display description on the right side using a two-column flex layout
- Left column: Title, Due Date, Opportunity badge, Priority/Effort/Tags
- Right column: Description (only rendered when present)

## Changes
- Added `.todo-info` CSS class for left column content
- Added `.todo-description` CSS class with subtle gray styling and 3-line truncation
- Updated `renderTodos()` to wrap existing content in `.todo-info` div and add description

## Test plan
- [x] Todo with description shows two-column layout
- [x] Todo without description shows only left column (no empty space)
- [x] Long descriptions are truncated with ellipsis
- [x] Completed todos show lighter description color
- [x] Layout works alongside recommendation panel

Fixes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)