### PR TITLE
Issue-72: Extend allocation timeline bar to show 12 months

### DIFF
--- a/ISSUETRACKER.md
+++ b/ISSUETRACKER.md
@@ -47,4 +47,4 @@ Issue-67: Added "Blocked" status for Todos with visual indicators, block/unblock
 
 Issue-69: Added allocation timeline bar to Engagement list items showing monthly allocations as colored pebbles (yellow for pre-project, green for project) with month labels, percentage display, and left/right arrow scrolling for timelines with more than 6 months.
 
-Issue-72: Extended allocation timeline bar to show 12 months at a time instead of 6, with scrolling for timelines exceeding 12 months.
+Issue-72: Extended allocation timeline bar to show 18 months at a time (up from 6), fixed pebble clipping by removing overflow constraints, scrolling appears for timelines exceeding 18 months.

--- a/src/index.html
+++ b/src/index.html
@@ -2007,13 +2007,12 @@
             color: #0288D1;
         }
 
-        /* Allocation timeline bar in engagement list (Issue-69) */
+        /* Allocation timeline bar in engagement list (Issue-69, Issue-72) */
         .allocation-timeline-bar {
             display: flex;
             align-items: center;
             gap: 4px;
             flex-shrink: 0;
-            max-width: 320px;
             margin-left: auto;
             margin-right: 16px;
         }
@@ -2046,7 +2045,6 @@
         .allocation-timeline-months {
             display: flex;
             gap: 4px;
-            overflow: hidden;
         }
 
         .allocation-pebble {
@@ -12303,11 +12301,11 @@
             // Get offset for this engagement's timeline
             const offset = engagementTimelineOffsets[engagement.id] || 0;
 
-            // Determine visible months (12 at a time) - Issue-72
-            const visibleMonths = allMonths.slice(offset, offset + 12);
+            // Determine visible months (18 at a time) - Issue-72
+            const visibleMonths = allMonths.slice(offset, offset + 18);
             const canScrollLeft = offset > 0;
-            const canScrollRight = offset + 12 < allMonths.length;
-            const needsArrows = allMonths.length > 12;
+            const canScrollRight = offset + 18 < allMonths.length;
+            const needsArrows = allMonths.length > 18;
 
             // Build pebbles HTML
             const pebblesHtml = visibleMonths.map(month => {
@@ -12377,7 +12375,7 @@
                     ? generateMonthRange(allocation.project.startMonth, allocation.project.endMonth)
                     : [];
                 const allMonths = [...new Set([...preProjectMonths, ...projectMonths])].sort();
-                const maxOffset = Math.max(0, allMonths.length - 12);
+                const maxOffset = Math.max(0, allMonths.length - 18);
                 engagementTimelineOffsets[engagementId] = Math.max(0, Math.min(engagementTimelineOffsets[engagementId], maxOffset));
             }
             renderEngagements();


### PR DESCRIPTION
## Summary
- Extended the allocation timeline bar in the Engagements list view to display 18 months at a time (up from 6)
- Fixed pebble clipping issue by removing `max-width` and `overflow: hidden` constraints
- All pebbles are now fully visible at both left and right edges when scrolling
- Scroll arrows only appear when timeline exceeds 18 months

Closes #72

## Changes
- Removed `max-width: 320px` from `.allocation-timeline-bar`
- Removed `overflow: hidden` from `.allocation-timeline-months`
- Updated JavaScript to use 18-month window instead of 6

## Test plan
- [x] Verify timeline shows up to 18 months without scroll arrows
- [x] Verify all pebbles are fully visible (no clipping at edges)
- [x] Verify scroll arrows appear when timeline exceeds 18 months
- [x] Verify pebble colors remain correct (yellow/green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)