### PR TITLE
Issue-85: Fix deadline date not populated when editing todo

### DIFF
--- a/ISSUETRACKER.md
+++ b/ISSUETRACKER.md
@@ -58,3 +58,5 @@ Issue-78: Added "Minimal Work" effort level (30 min), updated "Very Low" to 1 ho
 Issue-80: Introduced Meetings feature with new entity type (title, description, date, duration), Shift+M keyboard shortcut to create meetings on Todo's page, dedicated Meetings list section below Daily Load showing upcoming meetings grouped by Today/Tomorrow/Date, integration with Daily Load KPI (purple color coding), IndexedDB persistence, and bumped app to v1.2.0.
 
 Issue-82: Added Conflict Detection Modal for Calendar Exclusions - when adding holidays, PTO, or disabling work days, detects conflicting todos and meetings with options to move to next work day or delete, bumped app to v1.3.0.
+
+Issue-85: Fixed deadline date not populating when editing existing todo by using DateTimePicker's setValue API instead of direct input value assignment.

--- a/src/index.html
+++ b/src/index.html
@@ -8325,15 +8325,16 @@
                 todoDescriptionInput.value = todo.description || '';
 
                 // Handle deadline (support both new deadline and old dueDate)
+                // Use setDeadlineValue to properly update DateTimePicker display (Issue-85)
                 if (todo.deadline) {
-                    todoDeadlineInput.value = formatDateTimeLocal(new Date(todo.deadline));
+                    setDeadlineValue(new Date(todo.deadline));
                 } else if (todo.dueDate) {
                     // Convert old dueDate to deadline with default time
                     const oldDate = new Date(todo.dueDate);
                     oldDate.setHours(17, 0, 0, 0);
-                    todoDeadlineInput.value = formatDateTimeLocal(oldDate);
+                    setDeadlineValue(oldDate);
                 } else {
-                    todoDeadlineInput.value = getDefaultDeadline();
+                    setDeadlineValue(getDefaultDeadlineDate());
                 }
 
                 // Set effort
@@ -8360,8 +8361,8 @@
             } else {
                 // Create mode
                 modalTitle.textContent = 'New Todo';
-                // Set default deadline to 5 PM today
-                todoDeadlineInput.value = getDefaultDeadline();
+                // Set default deadline to 5 PM today (Issue-85)
+                setDeadlineValue(getDefaultDeadlineDate());
                 // Set default effort
                 todoEffortSelect.value = DEFAULT_EFFORT;
                 // Set default priority
@@ -16957,10 +16958,24 @@
         // DATETIME HELPERS
         // ========================================
 
-        function getDefaultDeadline() {
+        // Get default deadline as Date object (5 PM today)
+        function getDefaultDeadlineDate() {
             const now = new Date();
-            now.setHours(17, 0, 0, 0); // Default to 5 PM today
-            return formatDateTimeLocal(now);
+            now.setHours(17, 0, 0, 0);
+            return now;
+        }
+
+        function getDefaultDeadline() {
+            return formatDateTimeLocal(getDefaultDeadlineDate());
+        }
+
+        // Set deadline value using DateTimePicker API if available (Issue-85)
+        function setDeadlineValue(date) {
+            if (todoDeadlineInput._dtpInstance) {
+                todoDeadlineInput._dtpInstance.setValue(date);
+            } else {
+                todoDeadlineInput.value = formatDateTimeLocal(date);
+            }
         }
 
         function formatDateTimeLocal(date) {


### PR DESCRIPTION
## Summary
- Fixed bug where deadline date field appeared empty when editing an existing todo
- Added `setDeadlineValue()` helper function that uses DateTimePicker's setValue API to properly update both internal state and visible display
- Added `getDefaultDeadlineDate()` helper to return Date object for default deadline

## Root Cause
The custom DateTimePicker component hides the native `<input>` element and creates a `displayInput` to show formatted dates. When setting `todoDeadlineInput.value` directly, only the hidden native input was updated, not the visible display field.

## Test plan
- [x] Create a new todo with a deadline - verify deadline displays correctly in modal
- [x] Save the todo and verify deadline displays in the list
- [x] Edit the todo - verify deadline is populated in the modal (previously was empty)
- [x] Change the deadline and save - verify change persists

Fixes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)