### PR TITLE
Issue-97: Group recently completed/dropped todos in collapsible sections

### DIFF
--- a/ISSUETRACKER.md
+++ b/ISSUETRACKER.md
@@ -71,3 +71,5 @@ Issue-87: Modified Overdue column to only show completed overdue todos if they w
 
 Issue-88: Daily Load KPI now considers future pending tasks before suggesting "ask for work", showing "Easy workload" instead when future tasks exist.
 Issue-95: Fixed meeting stats to only count meetings for current day instead of all upcoming meetings.
+
+Issue-97: Added collapsible "Recently Completed" and "Recently Dropped" sections with configurable visibility threshold in new Tasks settings section.

--- a/src/index.html
+++ b/src/index.html
@@ -7336,7 +7336,9 @@
             <div style="text-align: left; margin-bottom: 24px;">
                 <h3 style="font-size: 16px; font-weight: 600; color: #1F1F1F; margin-bottom: 12px;">What's New</h3>
                 <ul style="margin: 0; padding-left: 20px; color: #374151; font-size: 14px; line-height: 1.8;">
-                    <li><strong>Conflict Detection</strong> - When adding holidays, PTO, or disabling work days, conflicts with scheduled todos and meetings are detected and you can choose to move or delete them</li>
+                    <li><strong>Collapsible Completed/Dropped Sections</strong> - Completed and dropped todos are now grouped into collapsible sections below the active todo list</li>
+                    <li><strong>Tasks Settings</strong> - New "Tasks" section in Settings with configurable visibility threshold (default: 5 days)</li>
+                    <li><strong>Cleaner Todo List</strong> - Older completed/dropped items are automatically hidden but remain in the system</li>
                 </ul>
             </div>
 
@@ -7571,7 +7573,7 @@
         // ========================================
         // APP VERSION
         // ========================================
-        const APP_VERSION = '1.3.0';
+        const APP_VERSION = '1.4.0';
 
         // ========================================
         // PLANNING SETTINGS - Defaults


### PR DESCRIPTION
## Summary
- Add collapsible "Recently Completed" and "Recently Dropped" sections below the active todo list
- Add configurable visibility threshold in new "Tasks" section in Settings (default: 5 days)
- Completed/dropped todos older than the threshold are hidden from UI but remain in the system
- All todos continue to be exported regardless of visibility

## Changes
- **Settings**: New "Tasks" section with configurable visibility threshold (1-365 days)
- **Todo List**: Active todos displayed first, followed by collapsible sections for recent completed/dropped
- **Collapsible Sections**: Green-tinted "Recently Completed" and red-tinted "Recently Dropped" sections
- **State**: Sections collapsed by default, expand state persisted during session
- **Version**: Bumped to v1.4.0

## Test Plan
- [x] Verify "Recently Completed" section appears when todos are completed
- [x] Verify sections are collapsed by default
- [x] Verify clicking section header expands/collapses content
- [x] Verify count badge shows correct number of items
- [x] Verify Tasks settings section appears with visibility threshold input
- [x] Verify visibility threshold can be changed and saved

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)